### PR TITLE
For loop pip editable

### DIFF
--- a/docker/macros.j2
+++ b/docker/macros.j2
@@ -25,7 +25,7 @@
 {%- if packages is sequence and packages|length > 0 -%}
     pip --no-cache-dir install --upgrade{{ ' ' }}
     {%- if constraints %}-c /requirements/upper-constraints.txt {% endif -%}
-    {%- for package in packages %}{% if package[0] == '/' %}-e{{ ' ' }}{% endif %}{{ package }}{{ ' ' }}{% endfor %}
+    {%- for package in packages %}{% if package[0] == '/' %}$( printf -- "-e %s " {{ package }}){% else %}{{ package }}{{ ' ' }}{% endif %}{% endfor %}
 {%- else -%}
     true
 {%- endif -%}


### PR DESCRIPTION
We want to install all directories passed to `macros.install_pip` in
editable mode. Doing this in one pip call, some packages were not
installed. This seems to be the case, when an earlier package has a
dependency on a later one. Pip would then take the upstream dependency
it found for the earlier package instead of our local directory and not
install that dependecy in editable mode.

Looking at the problem, we found the following possible fixes:
1) Move the dependency to the front by renaming.
	This did indeed help, but might break anytime in the future and also
	makes the directory names less readable.
2) Use `git+file://` for the directories.
	This did indeed help, but lets pip do another checkout of the
	repository into the venv incresing the container size. Additionally,
	we did not know why it worked, so it might break at any time in the
	future.
3) One `pip install` call per directory.
	Effectively using a for-loop to install every directoy in its own
	call to `pip install`. The downsides are probably longer
	container-build times and it doesn't work if one directory is a
	dependecy of another.

We opted for possibility 3) here.

Since doing one pip call per package is slow, we only added individual
pip call for directories. But since directories are often not passed as
list, but rather as shell glob (e.g. "/plugins/*"), we have to do a
shell for-loop instead of a jinja2 one.

I've seen the nice `{% set _ = package_names.append(package) %}` "hack"
first in the openstack-ansible-haproxy_server role.